### PR TITLE
Refer fork in Chef instead of repo in RiotGames

### DIFF
--- a/features/commands/install.feature
+++ b/features/commands/install.feature
@@ -60,7 +60,7 @@ Feature: berks install
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
       cookbook 'berkshelf-cookbook-fixture',
-        github: 'RiotGames/berkshelf-cookbook-fixture',
+        github: 'chef/berkshelf-cookbook-fixture',
         branch: 'deps'
       """
     And the cookbook store contains a cookbook "berkshelf" "1.0.0" with dependencies:
@@ -188,36 +188,36 @@ Feature: berks install
   Scenario: installing a demand from a Git location
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git"
+      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/chef/berkshelf-cookbook-fixture.git"
       """
     When I successfully run `berks install`
     Then the cookbook store should have the git cookbooks:
       | berkshelf-cookbook-fixture | 1.0.0 | a97b9447cbd41a5fe58eee2026e48ccb503bd3bc |
     And the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at master)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/chef/berkshelf-cookbook-fixture.git (at master)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at master)
+      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/chef/berkshelf-cookbook-fixture.git (at master)
       """
 
   Scenario: installing a demand from a Git location that has already been installed
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git"
+      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/chef/berkshelf-cookbook-fixture.git"
       """
     And the cookbook store has the git cookbooks:
       | berkshelf-cookbook-fixture | 1.0.0 | a97b9447cbd41a5fe58eee2026e48ccb503bd3bc |
     When I successfully run `berks install`
     Then the output should contain:
       """
-      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at master)
+      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/chef/berkshelf-cookbook-fixture.git (at master)
       """
 
   Scenario: installing a Berksfile that contains a Git location with a rel
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
       cookbook 'berkshelf-cookbook-fixture',
-        github: 'RiotGames/berkshelf-cookbook-fixture',
+        github: 'chef/berkshelf-cookbook-fixture',
         branch: 'rel',
         rel:    'cookbooks/berkshelf-cookbook-fixture'
       """
@@ -226,16 +226,16 @@ Feature: berks install
       | berkshelf-cookbook-fixture | 1.0.0 | 93f5768b7d14df45e10d16c8bf6fe98ba3ff809a |
     And the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at rel/cookbooks/berkshelf-cookbook-fixture)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/chef/berkshelf-cookbook-fixture.git (at rel/cookbooks/berkshelf-cookbook-fixture)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at rel/cookbooks/berkshelf-cookbook-fixture)
+      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/chef/berkshelf-cookbook-fixture.git (at rel/cookbooks/berkshelf-cookbook-fixture)
       """
 
   Scenario: installing a Berksfile that contains a Git location
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
       cookbook 'berkshelf-cookbook-fixture',
-        git: 'https://github.com/RiotGames/berkshelf-cookbook-fixture.git',
+        git: 'https://github.com/chef/berkshelf-cookbook-fixture.git',
         tag: 'v0.2.0'
       """
     When I successfully run `berks install`
@@ -247,76 +247,76 @@ Feature: berks install
   Scenario: installing a Berksfile that contains a Git location with a tag
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git", tag: "v0.2.0"
+      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/chef/berkshelf-cookbook-fixture.git", tag: "v0.2.0"
       """
     When I successfully run `berks install`
     Then the cookbook store should have the git cookbooks:
       | berkshelf-cookbook-fixture | 0.2.0 | 70a527e17d91f01f031204562460ad1c17f972ee |
     And the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/chef/berkshelf-cookbook-fixture.git (at v0.2.0)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
+      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/chef/berkshelf-cookbook-fixture.git (at v0.2.0)
       """
 
   Scenario: installing a Berksfile that contains a Git location with a ref
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git", ref: "70a527e17d91f01f031204562460ad1c17f972ee"
+      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/chef/berkshelf-cookbook-fixture.git", ref: "70a527e17d91f01f031204562460ad1c17f972ee"
       """
     When I successfully run `berks install`
     Then the cookbook store should have the git cookbooks:
       | berkshelf-cookbook-fixture | 0.2.0 | 70a527e17d91f01f031204562460ad1c17f972ee |
     And the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at 70a527e)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/chef/berkshelf-cookbook-fixture.git (at 70a527e)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at 70a527e)
+      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/chef/berkshelf-cookbook-fixture.git (at 70a527e)
       """
 
   Scenario: installing a Berksfile that contains a Git location with an abbreviated ref
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git", ref: "70a527e"
+      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/chef/berkshelf-cookbook-fixture.git", ref: "70a527e"
       """
     When I successfully run `berks install`
     Then the cookbook store should have the git cookbooks:
       | berkshelf-cookbook-fixture | 0.2.0 | 70a527e17d91f01f031204562460ad1c17f972ee |
     And the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at 70a527e)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/chef/berkshelf-cookbook-fixture.git (at 70a527e)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at 70a527e)
+      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/chef/berkshelf-cookbook-fixture.git (at 70a527e)
       """
 
   Scenario: installing a Berksfile that contains a GitHub location
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", github: "RiotGames/berkshelf-cookbook-fixture", tag: "v0.2.0"
+      cookbook "berkshelf-cookbook-fixture", github: "chef/berkshelf-cookbook-fixture", tag: "v0.2.0"
       """
     When I successfully run `berks install`
     Then the cookbook store should have the git cookbooks:
       | berkshelf-cookbook-fixture | 0.2.0 | 70a527e17d91f01f031204562460ad1c17f972ee |
     And the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/chef/berkshelf-cookbook-fixture.git (at v0.2.0)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
+      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/chef/berkshelf-cookbook-fixture.git (at v0.2.0)
       """
 
   Scenario: installing a Berksfile that contains a GitHub location
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", github: "RiotGames/berkshelf-cookbook-fixture", tag: "v0.2.0"
+      cookbook "berkshelf-cookbook-fixture", github: "chef/berkshelf-cookbook-fixture", tag: "v0.2.0"
       """
     When I successfully run `berks install`
     Then the cookbook store should have the git cookbooks:
       | berkshelf-cookbook-fixture | 0.2.0 | 70a527e17d91f01f031204562460ad1c17f972ee |
     And the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/chef/berkshelf-cookbook-fixture.git (at v0.2.0)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
+      Using berkshelf-cookbook-fixture (0.2.0) from https://github.com/chef/berkshelf-cookbook-fixture.git (at v0.2.0)
       """
 
   Scenario: running install when current project is a cookbook and the 'metadata' is specified
@@ -445,12 +445,12 @@ Feature: berks install
   Scenario: when a Git demand points to a branch that does not satisfy the version constraint
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", "1.0.0", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git", tag: "v0.2.0"
+      cookbook "berkshelf-cookbook-fixture", "1.0.0", git: "https://github.com/chef/berkshelf-cookbook-fixture.git", tag: "v0.2.0"
       """
     When I run `berks install`
     Then the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v0.2.0)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/chef/berkshelf-cookbook-fixture.git (at v0.2.0)
       The cookbook downloaded for berkshelf-cookbook-fixture (= 1.0.0) did not satisfy the constraint.
       """
     And the exit status should be "CookbookValidationFailure"
@@ -458,16 +458,16 @@ Feature: berks install
   Scenario: when a Git demand is defined and a cookbook of the same name and version is already in the cookbook store
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/RiotGames/berkshelf-cookbook-fixture.git", tag: "v1.0.0"
+      cookbook "berkshelf-cookbook-fixture", git: "https://github.com/chef/berkshelf-cookbook-fixture.git", tag: "v1.0.0"
       """
     And the cookbook store has the cookbooks:
       | berkshelf-cookbook-fixture | 1.0.0 |
     When I successfully run `berks install`
     Then the output should contain:
       """
-      Fetching 'berkshelf-cookbook-fixture' from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v1.0.0)
+      Fetching 'berkshelf-cookbook-fixture' from https://github.com/chef/berkshelf-cookbook-fixture.git (at v1.0.0)
       Fetching cookbook index from http://127.0.0.1:26310...
-      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/RiotGames/berkshelf-cookbook-fixture.git (at v1.0.0)
+      Using berkshelf-cookbook-fixture (1.0.0) from https://github.com/chef/berkshelf-cookbook-fixture.git (at v1.0.0)
       """
 
   Scenario: with a git error during download

--- a/features/commands/update.feature
+++ b/features/commands/update.feature
@@ -96,13 +96,13 @@ Feature: berks update
   Scenario: With a git location
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/RiotGames/berkshelf-cookbook-fixture'
+      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/chef/berkshelf-cookbook-fixture'
       """
     And I write to "Berksfile.lock" with:
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: https://github.com/RiotGames/berkshelf-cookbook-fixture
+          git: https://github.com/chef/berkshelf-cookbook-fixture
           revision: 70a527e17d91f01f031204562460ad1c17f972ee
 
       GRAPH
@@ -114,7 +114,7 @@ Feature: berks update
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: https://github.com/RiotGames/berkshelf-cookbook-fixture
+          git: https://github.com/chef/berkshelf-cookbook-fixture
           revision: a97b9447cbd41a5fe58eee2026e48ccb503bd3bc
 
       GRAPH

--- a/features/lockfile.feature
+++ b/features/lockfile.feature
@@ -169,14 +169,14 @@ Feature: Creating and reading the Berkshelf lockfile
   Scenario: Updating a Berksfile.lock with a git location
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/RiotGames/berkshelf-cookbook-fixture.git', ref: '919afa0c4'
+      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/chef/berkshelf-cookbook-fixture.git', ref: '919afa0c4'
       """
     When I successfully run `berks install`
     Then the file "Berksfile.lock" should contain:
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: https://github.com/RiotGames/berkshelf-cookbook-fixture.git
+          git: https://github.com/chef/berkshelf-cookbook-fixture.git
           revision: 919afa0c402089df23ebdf36637f12271b8a96b4
           ref: 919afa0
 
@@ -187,14 +187,14 @@ Feature: Creating and reading the Berkshelf lockfile
   Scenario: Updating a Berksfile.lock with a git location and a branch
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/RiotGames/berkshelf-cookbook-fixture.git', branch: 'master'
+      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/chef/berkshelf-cookbook-fixture.git', branch: 'master'
       """
     When I successfully run `berks install`
     Then the file "Berksfile.lock" should contain:
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: https://github.com/RiotGames/berkshelf-cookbook-fixture.git
+          git: https://github.com/chef/berkshelf-cookbook-fixture.git
           revision: a97b9447cbd41a5fe58eee2026e48ccb503bd3bc
           branch: master
 
@@ -205,14 +205,14 @@ Feature: Creating and reading the Berkshelf lockfile
   Scenario: Updating a Berksfile.lock with a git location and a tag
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/RiotGames/berkshelf-cookbook-fixture.git', tag: 'v0.2.0'
+      cookbook 'berkshelf-cookbook-fixture', git: 'https://github.com/chef/berkshelf-cookbook-fixture.git', tag: 'v0.2.0'
       """
     When I successfully run `berks install`
     Then the file "Berksfile.lock" should contain:
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: https://github.com/RiotGames/berkshelf-cookbook-fixture.git
+          git: https://github.com/chef/berkshelf-cookbook-fixture.git
           revision: 70a527e17d91f01f031204562460ad1c17f972ee
           tag: v0.2.0
 
@@ -223,14 +223,14 @@ Feature: Creating and reading the Berkshelf lockfile
   Scenario: Updating a Berksfile.lock with a GitHub location
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook 'berkshelf-cookbook-fixture', github: 'RiotGames/berkshelf-cookbook-fixture', ref: '919afa0c4'
+      cookbook 'berkshelf-cookbook-fixture', github: 'chef/berkshelf-cookbook-fixture', ref: '919afa0c4'
       """
     When I successfully run `berks install`
     Then the file "Berksfile.lock" should contain:
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: https://github.com/RiotGames/berkshelf-cookbook-fixture.git
+          git: https://github.com/chef/berkshelf-cookbook-fixture.git
           revision: 919afa0c402089df23ebdf36637f12271b8a96b4
           ref: 919afa0
 
@@ -241,14 +241,14 @@ Feature: Creating and reading the Berkshelf lockfile
   Scenario: Updating a Berksfile.lock when a git location with :rel
     Given I have a Berksfile pointing at the local Berkshelf API with:
       """
-      cookbook 'berkshelf-cookbook-fixture', github: 'RiotGames/berkshelf-cookbook-fixture', branch: 'rel', rel: 'cookbooks/berkshelf-cookbook-fixture'
+      cookbook 'berkshelf-cookbook-fixture', github: 'chef/berkshelf-cookbook-fixture', branch: 'rel', rel: 'cookbooks/berkshelf-cookbook-fixture'
       """
     When I successfully run `berks install`
     Then the file "Berksfile.lock" should contain:
       """
       DEPENDENCIES
         berkshelf-cookbook-fixture
-          git: https://github.com/RiotGames/berkshelf-cookbook-fixture.git
+          git: https://github.com/chef/berkshelf-cookbook-fixture.git
           revision: 93f5768b7d14df45e10d16c8bf6fe98ba3ff809a
           branch: rel
           rel: cookbooks/berkshelf-cookbook-fixture

--- a/lib/berkshelf/berksfile.rb
+++ b/lib/berkshelf/berksfile.rb
@@ -118,7 +118,7 @@ module Berkshelf
     #   cookbook 'artifact', path: '/Users/reset/code/artifact'
     #
     # @example a cookbook dependency that will be retrieved from a Git server
-    #   cookbook 'artifact', git: 'https://github.com/RiotGames/artifact-cookbook.git'
+    #   cookbook 'artifact', git: 'https://github.com/chef/artifact-cookbook.git'
     #
     # @overload cookbook(name, version_constraint, options = {})
     #   @param [#to_s] name

--- a/spec/support/git.rb
+++ b/spec/support/git.rb
@@ -5,7 +5,7 @@ module Berkshelf
       include Berkshelf::RSpec::PathHelpers
 
       def git_origin_for(repo, options = {})
-        "file://#{generate_fake_git_remote("git@github.com/RiotGames/#{repo}.git", options)}/.git"
+        "file://#{generate_fake_git_remote("git@github.com/chef/#{repo}.git", options)}/.git"
       end
 
       def generate_fake_git_remote(uri, options = {})


### PR DESCRIPTION
Signed-off-by: Vikram Karve <vikram.karve@progress.com>

### Description
refer last comment in https://github.com/chef/chef-workstation/issues/2649

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)