### PR TITLE
INFCT-88-fix uri open deprecation

### DIFF
--- a/lib/berkshelf/downloader.rb
+++ b/lib/berkshelf/downloader.rb
@@ -152,7 +152,7 @@ module Berkshelf
         unpack_dir   = Pathname.new(tmp_dir) + "#{name}-#{version}"
 
         url = remote_cookbook.location_path
-        open(url, "rb") do |remote_file|
+        URI.open(url, "rb") do |remote_file|
           archive_path.open("wb") { |local_file| local_file.write remote_file.read }
         end
 


### PR DESCRIPTION
Signed-off-by: kasif <kadnan@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

### Description
open-uri used to (before Ruby 3.0) overwrite Kernel#open with its own version which also supports reading from external URLs rather than simply opening local files or running commands.

As such, this behavior to overwrite Kernel#open was deprecated in Ruby 2.7 and finally removed in Ruby 3.0.

### Issues Resolved
https://chefio.atlassian.net/browse/INFCT-88

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)