### PR TITLE
Allow users to use octokit 5.x

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_dependency "retryable",            ">= 2.0", "< 4.0"
   s.add_dependency "solve",                "~> 4.0"
   s.add_dependency "thor",                 ">= 0.20"
-  s.add_dependency "octokit",              "~> 4.0"
+  s.add_dependency "octokit",              ">= 4.0", "< 6.0"
   s.add_dependency "mixlib-archive",       ">= 1.1.4", "< 2.0" # needed for ruby 3.0 / Dir.chdir removal
   s.add_dependency "concurrent-ruby",      "~> 1.0"
   s.add_dependency "chef",                 ">= 15.7.32" # needed for --skip-syntax-check


### PR DESCRIPTION
### Description
Relaxes `octokit` requirement to allow users to use octokit 5.x.

cf. https://github.com/octokit/octokit.rb/commit/9bb6362b39e17452b511f7e4e7cfcb064d95a181

### Issues Resolved
n/a

### Check List

- [n/a] New functionality includes tests
- [x] All tests pass
- [does not exist any more] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
