### PR TITLE
Remove entry about RELEASE_NOTES from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,3 @@ StackOverflow discussion that's relevant -->
 
 - [ ] New functionality includes tests
 - [ ] All tests pass
-- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)


### PR DESCRIPTION
### Description

Remove entry about RELEASE_NOTES from PR template as it does not exist any more.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)

### Issues Resolved
n/a

### Check List

- [n/a] New functionality includes tests
- [x] All tests pass