### PR TITLE
Use explicit hash for mock.

### DIFF
--- a/spec/unit/berkshelf/lockfile_spec.rb
+++ b/spec/unit/berkshelf/lockfile_spec.rb
@@ -231,8 +231,8 @@ describe Berkshelf::Lockfile do
         expect(Chef::Environment).to receive(:from_hash).with(env_hash).and_return(environment)
 
         expect(environment).to receive(:cookbook_versions).with(
-          "apt" => "= 1.0.0",
-          "jenkins" => "= 1.4.5"
+          {"apt" => "= 1.0.0",
+          "jenkins" => "= 1.4.5"}
         )
 
         expect(environment).to receive(:save)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

### Description
Using `("apt"=>"= 1.0.0", "jenkins" => "= 1.4.5")` instead of `({"apt"=>"= 1.0.0", "jenkins" => "= 1.4.5"})` implicitly converts into a hash that (possibly as of 3.x Ruby keyword argument inclusion?) doesn't quite match the value of an explicit hash literal.

```
       #<InstanceDouble(Chef::Environment) (anonymous)> received :cookbook_versions with unexpected arguments
         expected: ({"apt"=>"= 1.0.0", "jenkins"=>"= 1.4.5"})
              got: ({"apt"=>"= 1.0.0", "jenkins"=>"= 1.4.5"})
     # ./lib/berkshelf/lockfile.rb:223:in `block in apply'
     # ./lib/berkshelf/lockfile.rb:215:in `apply'
     # ./spec/unit/berkshelf/lockfile_spec.rb:239:in `block (4 levels) in <top (required)>'
     # /usr/local/bundle/ruby/3.1.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```

### Issues Resolved
<!--- List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant -->

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)