### PR TITLE
Fix cookbook dependency version validation against chef's required format to berks upload

### DIFF
--- a/lib/berkshelf/validator.rb
+++ b/lib/berkshelf/validator.rb
@@ -1,3 +1,5 @@
+require 'chef/version_class'
+
 module Berkshelf
   module Validator
     class << self
@@ -25,8 +27,17 @@ module Berkshelf
           base, name = Pathname.new(cookbook.path.to_s).split
 
           files = Dir.glob("#{name}/**/*.rb", base: base.to_s).select { |f| f =~ /[[:space:]]/ }
+          validate_versions(cookbook)
 
           raise InvalidCookbookFiles.new(cookbook, files) unless files.empty?
+        end
+      end
+
+      def validate_versions(cookbook)
+        cookbook_dependencies = cookbook.dependencies
+        cookbook_dependencies.each do |cookbook_name, cookbook_version|
+          version = cookbook_version.gsub(/[^\d,\.]/, '')
+          Chef::Version.new(version)
         end
       end
     end

--- a/spec/unit/berkshelf/validator_spec.rb
+++ b/spec/unit/berkshelf/validator_spec.rb
@@ -6,6 +6,7 @@ describe Berkshelf::Validator do
 
     it "raises an error when the cookbook has spaces in the files" do
       allow(Dir).to receive(:glob).and_return(["/there are/spaces/in this/recipes/default.rb"])
+      allow(cookbook).to receive(:dependencies).and_return({"cookbook" => "1.0.0"})
       expect do
         subject.validate_files(cookbook)
       end.to raise_error(Berkshelf::InvalidCookbookFiles)
@@ -13,6 +14,21 @@ describe Berkshelf::Validator do
 
     it "does not raise an error when the cookbook is valid" do
       allow(Dir).to receive(:glob).and_return(["/there-are/no-spaces/in-this/recipes/default.rb"])
+      allow(cookbook).to receive(:dependencies).and_return({"cookbook" => "1.0.0"})
+      expect do
+        subject.validate_files(cookbook)
+      end.to_not raise_error
+    end
+
+    it "raises an error when the cookbook version is not valid" do
+      allow(cookbook).to receive(:dependencies).and_return({"cookbook" => "1"})
+      expect do
+        subject.validate_files(cookbook)
+      end.to raise_error
+    end
+
+    it "does not raise an error when the cookbook version is valid" do
+      allow(cookbook).to receive(:dependencies).and_return({"cookbook" => "1.0"})
       expect do
         subject.validate_files(cookbook)
       end.to_not raise_error


### PR DESCRIPTION

### Description
Here, we add a cookbook version dependency validation that reuses the existing version validation logic of the Chef gem in ::Chef::Version.
This will fix the Invalid Cookbook dependency allowed to be uploaded using berks upload

### Issues Resolved
<!--- List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant -->
Fixes: https://github.com/chef/customer-bugs/issues/686

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)