### PR TITLE
Constrain minitar gem version and fix require

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -33,9 +33,17 @@ Gem::Specification.new do |s|
     "changelog_uri"   => "https://github.com/chef/berkshelf/blob/main/CHANGELOG.md",
   }
 
+  ruby_version = Gem::Version.new(RUBY_VERSION)
+
   s.add_dependency "mixlib-shellout",      ">= 2.0", "< 4.0"
   s.add_dependency "cleanroom",            "~> 1.0"
-  s.add_dependency "minitar",              ">= 0.6"
+
+  if ruby_version >= "3.1"
+    s.add_dependency "minitar",              "~> 1.0"
+  else
+    s.add_dependency "minitar",              "~> 0.12"
+  end
+
   s.add_dependency "retryable",            ">= 2.0", "< 4.0"
   s.add_dependency "solve",                "~> 4.0"
   s.add_dependency "thor",                 ">= 0.20"
@@ -44,8 +52,8 @@ Gem::Specification.new do |s|
   s.add_dependency "concurrent-ruby",      "~> 1.0"
   if RUBY_VERSION.match?(/3.0/)
     s.add_dependency "chef",                 "~> 17.0" # needed for --skip-syntax-check
-  elsif 
-    s.add_dependency "chef",                 ">= 15.7.32" 
+  elsif
+    s.add_dependency "chef",                 ">= 15.7.32"
   end
   s.add_dependency "chef-config"
   # this is required for Mixlib::Config#from_json

--- a/lib/berkshelf/packager.rb
+++ b/lib/berkshelf/packager.rb
@@ -1,4 +1,4 @@
-require "archive/tar/minitar"
+require "minitar"
 require "find" unless defined?(Find)
 require "zlib" unless defined?(Zlib)
 
@@ -47,7 +47,7 @@ module Berkshelf
         Find.find(source) do |entry|
           next if source == entry
 
-          Archive::Tar::Minitar.pack_file(entry, tar)
+          Minitar.pack_file(entry, tar)
         end
       ensure
         tar.close
@@ -79,12 +79,12 @@ module Berkshelf
     # @return [String]
     attr_reader :filename
 
-    # A private decorator for Archive::Tar::Minitar::Writer that
+    # A private decorator for Minitar::Writer that
     # turns absolute paths into relative ones.
     class RelativeTarWriter < SimpleDelegator # :nodoc:
       def initialize(io, base_path)
         @base_path = Pathname.new(base_path)
-        super(Archive::Tar::Minitar::Writer.new(io))
+        super(Minitar::Writer.new(io))
       end
 
       %w{add_file add_file_simple mkdir}.each do |method|


### PR DESCRIPTION
This should be just specifying `"~> 1.0"`, but backlevel support has
been added because Berkshelf still claims to support Ruby 2.7+ and
Minitar 1.0 (which is the only supported branch as of 20204-08-07) has
explicitly dropped support for any Ruby version 3.0 or older.

Minitar v0.12 is the last of the versions for that line and all users
are encouraged to upgrade to v1.0 (no one should be running anything
older than Ruby 3.1).

This is a fairly critical update as users of berkshelf are unable to
install or use it without this change.

I would strongly recommend that other dependencies like `thor` and
`chef` itself where there is an unconstrained `>=` specification be
reviewed. This is a potential security or incompatibility hole for all
of your users.

Resolves: #26
