### PR TITLE
Constrain minitar gem version and fix require

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -33,9 +33,18 @@ Gem::Specification.new do |s|
     "changelog_uri"   => "https://github.com/chef/berkshelf/blob/main/CHANGELOG.md",
   }
 
+  ruby_version = Gem::Version.new(RUBY_VERSION)
+
   s.add_dependency "mixlib-shellout",      ">= 2.0", "< 4.0"
+
   s.add_dependency "chef-cleanroom",            "~> 1.0"
-  s.add_dependency "minitar",              ">= 0.6"
+
+  if ruby_version >= "3.1"
+    s.add_dependency "minitar",              "~> 1.0"
+  else
+    s.add_dependency "minitar",              "~> 0.12"
+  end
+
   s.add_dependency "retryable",            ">= 2.0", "< 4.0"
   s.add_dependency "solve",                "~> 4.0"
   s.add_dependency "thor",                 ">= 0.20"

--- a/lib/berkshelf/packager.rb
+++ b/lib/berkshelf/packager.rb
@@ -1,4 +1,4 @@
-require "archive/tar/minitar"
+require "minitar"
 require "find" unless defined?(Find)
 require "zlib" unless defined?(Zlib)
 
@@ -47,7 +47,7 @@ module Berkshelf
         Find.find(source) do |entry|
           next if source == entry
 
-          Archive::Tar::Minitar.pack_file(entry, tar)
+          Minitar.pack_file(entry, tar)
         end
       ensure
         tar.close
@@ -79,12 +79,12 @@ module Berkshelf
     # @return [String]
     attr_reader :filename
 
-    # A private decorator for Archive::Tar::Minitar::Writer that
+    # A private decorator for Minitar::Writer that
     # turns absolute paths into relative ones.
     class RelativeTarWriter < SimpleDelegator # :nodoc:
       def initialize(io, base_path)
         @base_path = Pathname.new(base_path)
-        super(Archive::Tar::Minitar::Writer.new(io))
+        super(Minitar::Writer.new(io))
       end
 
       %w{add_file add_file_simple mkdir}.each do |method|


### PR DESCRIPTION
Conflict resolution of @halostatue's #27 PR

This should be just specifying `"~> 1.0"`, but backlevel support has been added because Berkshelf still claims to support Ruby 2.7+ and Minitar 1.0 (which is the only supported branch as of 20204-08-07) has explicitly dropped support for any Ruby version 3.0 or older.

Minitar v0.12 is the last of the versions for that line and all users are encouraged to upgrade to v1.0 (no one should be running anything older than Ruby 3.1).

This is a fairly critical update as users of berkshelf are unable to install or use it without this change.

I would strongly recommend that other dependencies like `thor` and `chef` itself where there is an unconstrained `>=` specification be reviewed. This is a potential security or incompatibility hole for all of your users.

Resolves: #26

<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Please describe what this change achieves -->

### Issues Resolved
<!--- List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant -->

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)