### PR TITLE
Fix version string comparison for Minitar and uncomment install feature

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -39,10 +39,17 @@ Gem::Specification.new do |s|
 
   s.add_dependency "chef-cleanroom",            "~> 1.0"
 
-  if ruby_version >= "3.1"
+  if ruby_version >= Gem::Version.new("3.1.0")
     s.add_dependency "minitar",              "~> 1.0"
+    s.add_dependency "chef",                 ">= 18.0.0"
   else
     s.add_dependency "minitar",              "~> 0.12"
+
+    if ruby_version >= Gem::Version.new("3.0.0")
+      s.add_dependency "chef",                 "~> 17.0" # needed for --skip-syntax-check
+    else
+      s.add_dependency "chef",                 ">= 15.7.32"
+    end
   end
 
   s.add_dependency "retryable",            ">= 2.0", "< 4.0"
@@ -54,11 +61,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "ffi",                "~> 1.9", "< 1.16.0" #
 
-  if RUBY_VERSION.match?(/3.0/)
-    s.add_dependency "chef",                 "~> 17.0" # needed for --skip-syntax-check
-  elsif
-    s.add_dependency "chef",                 ">= 15.7.32"
-  end
   s.add_dependency "chef-config"
   # this is required for Mixlib::Config#from_json
   s.add_dependency "mixlib-config", ">= 2.2.5"

--- a/features/commands/install.feature
+++ b/features/commands/install.feature
@@ -624,24 +624,24 @@ Feature: berks install
     Resolving cookbook dependencies...
     """
 
-#  Scenario: when using a chef_repo source
-#    Given I use a fixture named "complex-cookbook-path"
-#    And a file named "Berksfile" with:
-#      """
-#      source chef_repo: '.'
-#
-#      cookbook 'jenkins-config'
-#      """
-#    When I successfully run `berks install`
-#    Then the output should contain:
-#      """
-#      Installing jenkins (2.0.1) from
-#      """
-#    And the output should contain:
-#      """
-#      Installing jenkins-config (0.1.0) from
-#      """
-#    And the cookbook store should have the cookbooks:
-#      | jenkins        | 2.0.1 |
-#      | jenkins-config | 0.1.0 |
-#
+  Scenario: when using a chef_repo source
+    Given I use a fixture named "complex-cookbook-path"
+    And a file named "Berksfile" with:
+      """
+      source chef_repo: '.'
+
+      cookbook 'jenkins-config'
+      """
+    When I successfully run `berks install`
+    Then the output should contain:
+      """
+      Installing jenkins (2.0.1) from
+      """
+    And the output should contain:
+     """
+      Installing jenkins-config (0.1.0) from
+      """
+    And the cookbook store should have the cookbooks:
+      | jenkins        | 2.0.1 |
+      | jenkins-config | 0.1.0 |
+


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

### Description
Problem
```
❯ bundle update --conservative berkshelf
Warning: the running version of Bundler (2.2.33) is older than the version that created the lockfile (2.3.26). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.3.26`.
Fetching https://github.com/chef/berkshelf.git

[!] There was an error while loading `berkshelf.gemspec`: comparison of Gem::Version with String failed. Bundler cannot continue.

 #  from /Users/powell/.rbenv/versions/3.0.6/lib/ruby/gems/3.0.0/bundler/gems/berkshelf-cb35db3c8ac9/berkshelf.gemspec:42
 #  -------------------------------------------
 #
 >    if ruby_version >= "3.1"
 #      s.add_dependency "minitar",              "~> 1.0"
```

After pointing at this fix:
```
Using knife 17.10.162 from source at `../knife` and installing its executables
Using kitchen-inspec 2.5.2
Using berkshelf 8.0.12 (was 8.0.9) from https://github.com/chef/berkshelf.git (at tp/ruby-version-berkshelf@4400ffa)
Bundle updated!
Post-install message from minitar:
The `minitar` executable is no longer bundled with `minitar`. If you are
expecting this executable, make sure you also install `minitar-cli`.
```


### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)