### PR TITLE
PR #11 rebase Allow users to user octokit 5.x

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,3 @@ StackOverflow discussion that's relevant -->
 
 - [ ] New functionality includes tests
 - [ ] All tests pass
-- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)

--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -54,8 +54,10 @@ Gem::Specification.new do |s|
 
   s.add_dependency "retryable",            ">= 2.0", "< 4.0"
   s.add_dependency "solve",                "~> 4.0"
+
   s.add_dependency "thor",                 ">= 0.20", "< 1.3.0"
-  s.add_dependency "octokit",              "~> 4.0"
+  s.add_dependency "octokit",              ">= 4.0", "< 6.0"
+
   s.add_dependency "mixlib-archive",       ">= 1.1.4", "< 2.0" # needed for ruby 3.0 / Dir.chdir removal
   s.add_dependency "concurrent-ruby",      "~> 1.0"
 

--- a/lib/berkshelf/version.rb
+++ b/lib/berkshelf/version.rb
@@ -1,3 +1,3 @@
 module Berkshelf
-  VERSION = "8.0.14".freeze
+  VERSION = "8.1.0".freeze
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

### Description

#### Minor version bump, as Chef 17 and Ruby < 3.1 will not be able to use the published gem (GitHub install from main will still work)

#### Incorporate #11 

Relaxes `octokit` requirement to allow users to use octokit 5.x.

cf. https://github.com/octokit/octokit.rb/commit/9bb6362b39e17452b511f7e4e7cfcb064d95a181

#### and #13 Remove entry about RELEASE_NOTES from PR template from https://github.com/tnir

Remove entry about RELEASE_NOTES from PR template as it does not exist any more.


### Issues Resolved
<!--- List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant -->

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)