### PR TITLE
Move syslog dependency from Gemfile to gemspec

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -29,7 +29,6 @@ steps:
     - rm -f .bundle/config
     - apt-get update -y
     - apt-get install -y graphviz
-    - export CXXFLAGS="-std=c++11"
     - bundle config set --local path 'vendor/bundle'
     - bundle install --jobs=3 --retry=3
     - bundle exec rake

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -29,6 +29,10 @@ steps:
     - rm -f .bundle/config
     - apt-get update -y
     - apt-get install -y graphviz
+    # Add legacy C++ flags to work around Gecode build issues
+    - export CXXFLAGS="-std=gnu++98 -Wno-error=terminate -Wno-error=deprecated-copy"
+    - export CPPFLAGS="$CXXFLAGS"
+    - export CFLAGS="$CXXFLAGS"
     - bundle config set --local path 'vendor/bundle'
     - bundle install --jobs=3 --retry=3
     - bundle exec rake

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -23,16 +23,12 @@ steps:
         image: rubydistros/ubuntu-22.04:3.1
         privileged: true
 
-- label: "Integration Ubuntu 22.04 :ruby: 3.4"
+- label: "Integration Ubuntu 24.04 :ruby: 3.4"
   commands:
     - cd /workdir
     - rm -f .bundle/config
     - apt-get update -y
     - apt-get install -y graphviz
-    # Add legacy C++ flags to work around Gecode build issues
-    # - export CXXFLAGS="-std=gnu++98 -Wno-error=terminate -Wno-error=deprecated-copy"
-    # - export CPPFLAGS="$CXXFLAGS"
-    # - export CFLAGS="$CXXFLAGS"
     - bundle config set --local path 'vendor/bundle'
     - bundle install --jobs=3 --retry=3
     - bundle exec rake

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -30,14 +30,14 @@ steps:
     - apt-get update -y
     - apt-get install -y graphviz
     # Add legacy C++ flags to work around Gecode build issues
-    - export CXXFLAGS="-std=gnu++98 -Wno-error=terminate -Wno-error=deprecated-copy"
-    - export CPPFLAGS="$CXXFLAGS"
-    - export CFLAGS="$CXXFLAGS"
+    # - export CXXFLAGS="-std=gnu++98 -Wno-error=terminate -Wno-error=deprecated-copy"
+    # - export CPPFLAGS="$CXXFLAGS"
+    # - export CFLAGS="$CXXFLAGS"
     - bundle config set --local path 'vendor/bundle'
     - bundle install --jobs=3 --retry=3
     - bundle exec rake
   expeditor:
     executor:
       docker:
-        image: ruby:3.4
+        image: rubydistros/ubuntu-24.04:3.4
         privileged: true

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -29,6 +29,7 @@ steps:
     - rm -f .bundle/config
     - apt-get update -y
     - apt-get install -y graphviz
+    - export CXXFLAGS="-std=c++11"
     - bundle config set --local path 'vendor/bundle'
     - bundle install --jobs=3 --retry=3
     - bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,10 @@ jobs:
       matrix:
         os: [ubuntu, macos]
         ruby: [3.1, 3.4]
+    container: ${{ (matrix.os == 'ubuntu' && matrix.ruby == '3.4') && 'rubydistros/ubuntu-24.04:3.4' || '' }}
     steps:
     - run: |
-         if [ "$RUNNER_OS" == "Linux" ]; then
+         if [ "$RUNNER_OS" == "Linux" ] && [ "${{ matrix.ruby }}" != "3.4" ]; then
            sudo apt-get update && sudo apt-get install graphviz libarchive-dev
          elif [ "$RUNNER_OS" == "Windows" ]; then
            choco install graphviz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,17 @@ jobs:
         ruby: [3.1, 3.4]
     container: ${{ (matrix.os == 'ubuntu' && matrix.ruby == '3.4') && 'rubydistros/ubuntu-24.04:3.4' || '' }}
     steps:
+    - uses: actions/checkout@v2
     - run: |
-         if [ "$RUNNER_OS" == "Linux" ] && [ "${{ matrix.ruby }}" != "3.4" ]; then
-           sudo apt-get update && sudo apt-get install graphviz libarchive-dev
+         if [ "$RUNNER_OS" == "Linux" ]; then
+           if [ "${{ matrix.ruby }}" == "3.1" ]; then
+             # For Ruby 3.1 on standard Ubuntu runner
+             sudo apt-get update && sudo apt-get install -y graphviz libarchive-dev
+           elif [ "${{ matrix.ruby }}" == "3.4" ]; then
+             # For Ruby 3.4 in custom container with old toolchains, skip dependency installation
+             # Dependencies should already be available in the custom image
+             echo "Using custom Ruby 3.4 image with pre-installed dependencies"
+           fi
          elif [ "$RUNNER_OS" == "Windows" ]; then
            choco install graphviz
          elif [ "$RUNNER_OS" == "macOS" ]; then
@@ -36,7 +44,6 @@ jobs:
            exit 1
          fi
       shell: bash
-    - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,8 @@ jobs:
              # For Ruby 3.1 on standard Ubuntu runner
              sudo apt-get update && sudo apt-get install -y graphviz libarchive-dev
            elif [ "${{ matrix.ruby }}" == "3.4" ]; then
-             # For Ruby 3.4 in custom container with old toolchains, skip dependency installation
-             # Dependencies should already be available in the custom image
-             echo "Using custom Ruby 3.4 image with pre-installed dependencies"
+             # For Ruby 3.4 in custom container, install without sudo
+             apt-get update && apt-get install -y graphviz libarchive-dev
            fi
          elif [ "$RUNNER_OS" == "Windows" ]; then
            choco install graphviz

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,6 @@ group :build do
   gem "rake", ">= 10.1"
 end
 
-gem "syslog"
-
 group :development do
   gem "debug"
   gem "aruba",         "~> 2.3"

--- a/Gemfile
+++ b/Gemfile
@@ -12,13 +12,15 @@ group :development do
   gem "cucumber",      ">= 9.2", "< 10"
   gem "cucumber-cucumber-expressions", "~> 17.1"
   gem "chef-zero",     ">= 4.0"
-  gem "dep_selector",  ">= 1.0"
   gem "fuubar",        ">= 2.0"
   gem "rspec",         ">= 3.0"
   gem "rspec-its",     ">= 1.2"
   gem "webmock",       ">= 1.11"
   gem "http",          ">= 0.9.8"
   gem "chefstyle"
+  if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("3.1.0")
+    gem "dep_selector", ">= 1.0"
+  end
 end
 
 gem "appbundler"

--- a/Gemfile
+++ b/Gemfile
@@ -12,15 +12,13 @@ group :development do
   gem "cucumber",      ">= 9.2", "< 10"
   gem "cucumber-cucumber-expressions", "~> 17.1"
   gem "chef-zero",     ">= 4.0"
+  gem "dep_selector",  ">= 1.0"
   gem "fuubar",        ">= 2.0"
   gem "rspec",         ">= 3.0"
   gem "rspec-its",     ">= 1.2"
   gem "webmock",       ">= 1.11"
   gem "http",          ">= 0.9.8"
   gem "chefstyle"
-  if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("3.1.0")
-    gem "dep_selector", ">= 1.0"
-  end
 end
 
 gem "appbundler"

--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -66,5 +66,5 @@ Gem::Specification.new do |s|
   s.add_dependency "chef-config"
   # this is required for Mixlib::Config#from_json
   s.add_dependency "mixlib-config", ">= 2.2.5"
-  s.add_dependency "syslog",               "~> 0.3"
+  s.add_dependency "syslog", "~> 0.3"
 end

--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
 
   if ruby_version >= Gem::Version.new("3.1.0")
     s.add_dependency "minitar",              "~> 1.0"
-    s.add_dependency "chef",                 ">= 18.0.0"
+    s.add_dependency "chef",                 "=18.7.10"
   else
     s.add_dependency "minitar",              "~> 0.12"
 

--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -66,4 +66,5 @@ Gem::Specification.new do |s|
   s.add_dependency "chef-config"
   # this is required for Mixlib::Config#from_json
   s.add_dependency "mixlib-config", ">= 2.2.5"
+  s.add_dependency "syslog",               "~> 0.3"
 end

--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
 
   if ruby_version >= Gem::Version.new("3.1.0")
     s.add_dependency "minitar",              "~> 1.0"
-    s.add_dependency "chef",                 "=18.7.10"
+    s.add_dependency "chef",                 ">= 18.0.0"
   else
     s.add_dependency "minitar",              "~> 0.12"
 

--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -66,5 +66,10 @@ Gem::Specification.new do |s|
   s.add_dependency "chef-config"
   # this is required for Mixlib::Config#from_json
   s.add_dependency "mixlib-config", ">= 2.2.5"
-  s.add_dependency "syslog", "~> 0.3"
+
+  # This gem was removed from the Ruby standard library starting with version 3.4
+  # See: https://stdgems.org/new-in/3.4
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4")
+    s.add_dependency "syslog", "~> 0.3"
+  end
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

### Description
In Ruby 3.4, syslog is no longer part of the stdlib and must be declared explicitly. Moved syslog from the Gemfile to the gemspec so it is always installed as a runtime dependency and prevents LoadError when loading chef/environment.

### Issues Resolved
<!--- List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant -->

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] RELEASE\_NOTES.md has been updated if required (not required for bugfixes, required for API changes)