### PR TITLE
Remove Ruby version conditional logic for syslog from gemspec

### DIFF
--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -66,7 +66,5 @@ Gem::Specification.new do |s|
   s.add_dependency "chef-config"
   # this is required for Mixlib::Config#from_json
   s.add_dependency "mixlib-config", ">= 2.2.5"
-
-  # syslog was removed from Ruby's standard library in 3.4; see https://stdgems.org/new-in/3.4
   s.add_dependency "syslog", "~> 0.3"
 end

--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -67,9 +67,6 @@ Gem::Specification.new do |s|
   # this is required for Mixlib::Config#from_json
   s.add_dependency "mixlib-config", ">= 2.2.5"
 
-  # This gem was removed from the Ruby standard library starting with version 3.4
-  # See: https://stdgems.org/new-in/3.4
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4")
-    s.add_dependency "syslog", "~> 0.3"
-  end
+  # syslog was removed from Ruby's standard library in 3.4; see https://stdgems.org/new-in/3.4
+  s.add_dependency "syslog", "~> 0.3"
 end

--- a/berkshelf.gemspec
+++ b/berkshelf.gemspec
@@ -66,5 +66,7 @@ Gem::Specification.new do |s|
   s.add_dependency "chef-config"
   # this is required for Mixlib::Config#from_json
   s.add_dependency "mixlib-config", ">= 2.2.5"
+
+  # syslog was removed from Ruby's standard library in 3.4; see https://stdgems.org/new-in/3.4
   s.add_dependency "syslog", "~> 0.3"
 end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

### Description
This PR removes the Ruby version conditional logic for the syslog dependency from the gemspec file.

### Issues Resolved
<!--- List any existing issues this PR resolves, or any Discourse or
StackOverflow discussion that's relevant -->

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
