### PR TITLE
CHEF-35087: Use appbundler for binstub generation in hab packaging and install latest Habitat in Windows test

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -9,7 +9,6 @@ $env:HAB_BLDR_CHANNEL = 'base-2025'
 $env:HAB_REFRESH_CHANNEL = "base-2025"
 $env:CHEF_LICENSE = 'accept-no-persist'
 $env:HAB_LICENSE = 'accept-no-persist'
-$HabitatVersion = if ($env:HAB_VERSION) { $env:HAB_VERSION } else { '1.6.1245' }
 $Plan = 'berkshelf'
 
 Write-Host "--- system details"
@@ -28,22 +27,8 @@ function Stop-HabProcess {
 
 # Installing Habitat
 function Install-Habitat {
-  param(
-    [Parameter(Mandatory = $true)]
-    [string]$Version
-  )
-
-  Write-Host "Downloading and installing Habitat version $Version..."
-  $installScriptUrl = 'https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'
-  $installScriptPath = Join-Path $env:TEMP "hab-install-$Version.ps1"
-
-  Invoke-WebRequest -Uri $installScriptUrl -OutFile $installScriptPath
-  try {
-    & $installScriptPath -Version $Version
-  }
-  finally {
-    Remove-Item $installScriptPath -Force -ErrorAction SilentlyContinue
-  }
+  Write-Host "Downloading and installing Habitat..."
+  Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
 }
 
 try {
@@ -66,9 +51,9 @@ catch {
       }
   }
 
-  Install-Habitat -Version $HabitatVersion
+  Install-Habitat
   Write-Host "******************************************************************"
-  Write-Host "** What is My Hab Vewrsion after installation? $(hab --version)"
+  Write-Host "** What is My Hab Version after installation? $(hab --version)"
   Write-Host "******************************************************************"
 }
 finally {
@@ -83,9 +68,6 @@ Write-Host "--- Generating fake origin key"
 hab origin key generate $env:HAB_ORIGIN
 
 Write-Host "--- Building $Plan"
-Write-Host "******************************************************************"
-Write-Host "** What is My Project Root as determined by git rev? $(git rev-parse --show-toplevel)"
-Write-Host "******************************************************************"
 $project_root = "$(git rev-parse --show-toplevel)"
 Set-Location $project_root
 

--- a/binstub_patch.rb
+++ b/binstub_patch.rb
@@ -1,8 +1,4 @@
 unless ENV["APPBUNDLER_ALLOW_RVM"]
   ENV["APPBUNDLER_ALLOW_RVM"] = "true"
-  bin_path = __dir__
-  vendor_path = File.expand_path(File.join(bin_path, "..", "vendor"))
-  ENV["GEM_HOME"] = vendor_path
-  ENV["GEM_PATH"] = [vendor_path, ENV["GEM_PATH"]].compact.join(File::PATH_SEPARATOR)
-  ENV["PATH"] = [bin_path, File.join(vendor_path, "bin"), RbConfig::CONFIG["bindir"], ENV["PATH"]].compact.join(File::PATH_SEPARATOR)
+  ENV["GEM_PATH"] = [File.expand_path(File.join(__dir__, "..", "vendor")), ENV["GEM_PATH"]].compact.join(File::PATH_SEPARATOR)
 end

--- a/binstub_patch.rb
+++ b/binstub_patch.rb
@@ -1,0 +1,8 @@
+unless ENV["APPBUNDLER_ALLOW_RVM"]
+  ENV["APPBUNDLER_ALLOW_RVM"] = "true"
+  bin_path = __dir__
+  vendor_path = File.expand_path(File.join(bin_path, "..", "vendor"))
+  ENV["GEM_HOME"] = vendor_path
+  ENV["GEM_PATH"] = [vendor_path, ENV["GEM_PATH"]].compact.join(File::PATH_SEPARATOR)
+  ENV["PATH"] = [bin_path, File.join(vendor_path, "bin"), RbConfig::CONFIG["bindir"], ENV["PATH"]].compact.join(File::PATH_SEPARATOR)
+end

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -98,11 +98,9 @@ function Invoke-Install {
     try {
         Push-Location $pkg_prefix
         bundle _2.3.3_ config --local gemfile $project_root/Gemfile
-         Write-BuildLine "** generating binstubs for berkshelf with precise version pins"
-	 Write-BuildLine "** generating binstubs for berkshelf with precise version pins $project_root $pkg_prefix/bin "
-            Invoke-Expression -Command "appbundler.bat $project_root $pkg_prefix/bin berkshelf"
-            If ($lastexitcode -ne 0) { Exit $lastexitcode }
-	Write-BuildLine " ** Running the berkshelf project's 'rake install' to install the path-based gems so they look like any other installed gem."
+        Write-BuildLine "** generating binstubs for berkshelf with precise version pins $project_root $pkg_prefix/bin "
+        Invoke-Expression -Command "appbundler.bat $project_root $pkg_prefix/bin berkshelf"
+        If ($lastexitcode -ne 0) { Exit $lastexitcode }
 
         If ($lastexitcode -ne 0) { Exit $lastexitcode }
     } finally {
@@ -123,6 +121,10 @@ function Invoke-After {
     # only inspec's for package verification.
     Get-ChildItem $pkg_prefix/vendor/gems -Filter "spec" -Directory -Recurse -Depth 1 `
         | Where-Object -FilterScript { $_.FullName -notlike "*berkshelf*" }             `
+        | Remove-Item -Recurse -Force
+    # Remove .github directories from vendored gems to avoid shipping GHA workflow
+    # files that trigger grype vulnerability reports (e.g. step-security/harden-runner CVEs).
+    Get-ChildItem $pkg_prefix/vendor/gems -Filter ".github" -Directory -Recurse `
         | Remove-Item -Recurse -Force
     # Remove the byproducts of compiling gems with extensions
     Get-ChildItem $pkg_prefix/vendor/gems -Include @("gem_make.out", "mkmf.log", "Makefile") -File -Recurse `

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -10,8 +10,8 @@ pkg_deps=(${ruby_pkg} core/coreutils)
 pkg_bin_dirs=(bin)
 pkg_build_deps=(
   core/make
-  core/bash
   core/gcc
+  core/sed
 )
 
 do_setup_environment() {
@@ -20,6 +20,10 @@ do_setup_environment() {
 
   build_line "Setting GEM_PATH=$GEM_HOME"
   export GEM_PATH="$GEM_HOME"
+}
+
+do_prepare() {
+  ln -sf "$(pkg_interpreter_for core/ruby3_4 bin/ruby)" "$(pkg_interpreter_for core/coreutils bin/env)"
 }
 
 pkg_version() {
@@ -40,15 +44,11 @@ do_build() {
 
   build_line "Setting GEM_PATH=$GEM_HOME"
   export GEM_PATH="$GEM_HOME"
-  
-  build_line "Installing bundler 2.3.3"
-  gem install bundler -v 2.3.3 --force --no-document
-  
-  bundle _2.3.3_ config --local without integration deploy maintenance
-  bundle _2.3.3_ config --local jobs 4
-  bundle _2.3.3_ config --local retry 5
-  bundle _2.3.3_ config --local silence_root_warning 1
-  bundle _2.3.3_ install --without development --jobs=3 --retry=3
+  bundle config --local without integration deploy maintenance test development profile
+  bundle config --local jobs 4
+  bundle config --local retry 5
+  bundle config --local silence_root_warning 1
+  bundle install
   gem build berkshelf.gemspec
 }
 
@@ -67,35 +67,26 @@ do_install() {
   build_line "Setting GEM_PATH=$GEM_HOME"
   export GEM_PATH="$GEM_HOME"
   gem install berkshelf-*.gem --no-document
-  wrap_ruby_berkshelf
-  set_runtime_env "GEM_PATH" "${pkg_prefix}/vendor"
 
+  build_line "** generating binstubs for berkshelf with precise version pins"
+  "$(pkg_path_for $ruby_pkg)/bin/ruby" "${pkg_prefix}/vendor/bin/appbundler" . "$pkg_prefix/bin" berkshelf
+
+  build_line "** patching binstubs to allow running directly"
+  for binstub in ${pkg_prefix}/bin/*; do
+    sed -i "/require \"rubygems\"/r ${PLAN_CONTEXT}/../binstub_patch.rb" "$binstub"
+  done
+
+  fix_interpreter "${pkg_prefix}/bin/*" "$ruby_pkg" bin/ruby
+
+  rm -rf $GEM_PATH/cache/
+  rm -rf $GEM_PATH/bundler
+  rm -rf $GEM_PATH/doc
 }
 
-wrap_ruby_berkshelf() {
-  local bin="$pkg_prefix/bin/berks"
-  local real_bin="$GEM_HOME/gems/berkshelf-${pkg_version}/bin/berks"
-  wrap_bin_with_ruby "$bin" "$real_bin"
-}
-
-wrap_bin_with_ruby() {
-  local bin="$1"
-  local real_bin="$2"
-  build_line "Adding wrapper $bin to $real_bin"
-  cat <<EOF > "$bin"
-#!$(pkg_path_for core/bash)/bin/bash
-set -e
-
-# Set binary path that allows berkshelf to use non-Hab pkg binaries
-export PATH="/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
-
-# Set Ruby paths defined from 'do_setup_environment()'
-export GEM_HOME="$pkg_prefix/vendor"
-export GEM_PATH="$GEM_PATH"
-
-exec $(pkg_path_for ${ruby_pkg})/bin/ruby $real_bin \$@
-EOF
-  chmod -v 755 "$bin"
+do_after() {
+  build_line "Removing .github directories from vendored gems..."
+  find "$pkg_prefix/vendor/gems" -type d -name ".github" \
+      | while read github_dir; do rm -rf "$github_dir"; done
 }
 
 do_strip() {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -11,7 +11,6 @@ pkg_bin_dirs=(bin)
 pkg_build_deps=(
   core/make
   core/gcc
-  core/sed
 )
 
 do_setup_environment() {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -69,7 +69,7 @@ do_install() {
   gem install berkshelf-*.gem --no-document
 
   build_line "** generating binstubs for berkshelf with precise version pins"
-  "${pkg_prefix}/vendor/bin/appbundler" . "$pkg_prefix/bin" berkshelf
+  "$(pkg_path_for $ruby_pkg)/bin/ruby" "${pkg_prefix}/vendor/bin/appbundler" . "$pkg_prefix/bin" berkshelf
 
   build_line "** patching binstubs to allow running directly"
   for binstub in ${pkg_prefix}/bin/*; do

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -69,7 +69,7 @@ do_install() {
   gem install berkshelf-*.gem --no-document
 
   build_line "** generating binstubs for berkshelf with precise version pins"
-  "$(pkg_path_for $ruby_pkg)/bin/ruby" "${pkg_prefix}/vendor/bin/appbundler" . "$pkg_prefix/bin" berkshelf
+  "${pkg_prefix}/vendor/bin/appbundler" . "$pkg_prefix/bin" berkshelf
 
   build_line "** patching binstubs to allow running directly"
   for binstub in ${pkg_prefix}/bin/*; do

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -15,15 +15,17 @@ pkg_build_deps=(
 )
 
 do_setup_environment() {
-  build_line 'Setting GEM_HOME="$pkg_prefix/vendor"'
-  export GEM_HOME="$pkg_prefix/vendor"
+  push_runtime_env GEM_PATH "${pkg_prefix}/vendor"
 
-  build_line "Setting GEM_PATH=$GEM_HOME"
-  export GEM_PATH="$GEM_HOME"
+  set_runtime_env APPBUNDLER_ALLOW_RVM "true" # prevent appbundler from clearing out the carefully constructed runtime GEM_PATH
+  set_runtime_env LANG "en_US.UTF-8"
+  set_runtime_env LC_CTYPE "en_US.UTF-8"
 }
 
 do_prepare() {
-  ln -sf "$(pkg_interpreter_for core/ruby3_4 bin/ruby)" "$(pkg_interpreter_for core/coreutils bin/env)"
+  if [[ ! -f /usr/bin/env ]]; then
+    ln -s "$(pkg_interpreter_for core/coreutils bin/env)" /usr/bin/env
+  fi
 }
 
 pkg_version() {
@@ -69,7 +71,7 @@ do_install() {
   gem install berkshelf-*.gem --no-document
 
   build_line "** generating binstubs for berkshelf with precise version pins"
-  "$(pkg_path_for $ruby_pkg)/bin/ruby" "${pkg_prefix}/vendor/bin/appbundler" . "$pkg_prefix/bin" berkshelf
+  "${pkg_prefix}/vendor/bin/appbundler" . "$pkg_prefix/bin" berkshelf
 
   build_line "** patching binstubs to allow running directly"
   for binstub in ${pkg_prefix}/bin/*; do
@@ -91,4 +93,11 @@ do_after() {
 
 do_strip() {
   return 0
+}
+
+do_end() {
+  if [[ "$(readlink /usr/bin/env)" = "$(pkg_interpreter_for core/coreutils bin/env)" ]]; then
+    build_line "Removing the symlink we created for '/usr/bin/env'"
+    rm /usr/bin/env
+  fi
 }


### PR DESCRIPTION
This pull request makes several improvements to the Habitat packaging and build process for Berkshelf, focusing on simplifying environment setup, improving binstub handling, and cleaning up vendored gems to reduce potential vulnerabilities. The changes modernize the build scripts, ensure a more robust runtime environment, and remove unnecessary or problematic files from the package.

**Build and Environment Improvements:**

* Simplified the Habitat installation process in `.expeditor/buildkite/artifact.habitat.test.ps1` by removing the explicit version pin and custom script download, now using a direct invocation of the official install script. [[1]](diffhunk://#diff-ed5d080ecf41ee08c4d50b0c9d4fae51157b6b4b743dcb69b38250e50e498552L12) [[2]](diffhunk://#diff-ed5d080ecf41ee08c4d50b0c9d4fae51157b6b4b743dcb69b38250e50e498552L31-R31) [[3]](diffhunk://#diff-ed5d080ecf41ee08c4d50b0c9d4fae51157b6b4b743dcb69b38250e50e498552L69-R56)
* Updated environment variable handling in `habitat/plan.sh` to use `push_runtime_env` and `set_runtime_env` for `GEM_PATH` and other locales, and to prevent appbundler from clearing the runtime `GEM_PATH`.
* Added a patch (`binstub_patch.rb`) to ensure binstubs allow RVM and set the correct `GEM_PATH`, improving compatibility when running Berkshelf binaries.

**Build Process and Binstub Generation:**

* Switched from custom Ruby wrapper scripts to using `appbundler` for generating binstubs, and automated patching of these binstubs to ensure proper environment setup. [[1]](diffhunk://#diff-5901a181ccb1fa37ee65d1dcacf22edee3996d0360fdcf54dd1b4265ceaacfaaL70-R103) [[2]](diffhunk://#diff-9369dcde2f89abf07f786471eddf21551e7056466860f59b01c996e2aacf3df1L101-L105)
* Updated bundler and gem installation steps to simplify and modernize the build process, including removing unnecessary version pins and improving bundle configuration.