### PR TITLE
CHEF-37331: add Linux ARM Habitat validation in Expeditor pipeline

### DIFF
--- a/.expeditor/habitat-test.pipeline.yml
+++ b/.expeditor/habitat-test.pipeline.yml
@@ -20,6 +20,20 @@ steps:
           environment:
             - HAB_AUTH_TOKEN
 
+  - label: ":linux: Arm64 Validate Habitat Builds of Berkshelf"
+    commands:
+      - .expeditor/buildkite/artifact.habitat.test.sh
+    agents:
+      queue: default-privileged-aarch64
+    plugins:
+      - docker#v3.5.0:
+          image: ruby:3.4
+          privileged: true
+          propagate-environment: true
+          environment:
+            - HAB_AUTH_TOKEN
+            - BUILD_PKG_TARGET: "aarch64-linux"
+
   - label: ":windows: Validate Habitat Builds of Berkshelf"
     commands:
       - .expeditor/buildkite/artifact.habitat.test.ps1

--- a/habitat/aarch64-linux/plan.sh
+++ b/habitat/aarch64-linux/plan.sh
@@ -1,0 +1,2 @@
+source "$(dirname "${BASH_SOURCE[0]}")/../plan.sh"
+# Reuse the default Linux plan for Linux ARM (aarch64) builds.


### PR DESCRIPTION
## Summary
Adds Linux ARM64 (aarch64) Habitat build validation to the berkshelf Expeditor/Buildkite pipeline

## What Changed
- Added a new `":linux: Arm64 Validate Habitat Builds of berkshelf"` step to `.expeditor/habitat-test.pipeline.yml`
- Runs on Buildkite queue `default-privileged-aarch64`
- Uses the `docker#v3.5.0` plugin with image `ruby:3.4`, `privileged: true`, `propagate-environment: true`
- Sets `BUILD_PKG_TARGET: "aarch64-linux"`
- Keeps `HAB_AUTH_TOKEN` propagated via the environment, consistent with the existing Linux/Windows steps

## Result
Habitat package builds for berkshelf are now validated on Linux ARM64 via Buildkite/Expeditor, in addition to the existing Linux (x86_64) and Windows validation steps.

## Jira
CHEF-37331