### PR TITLE
CHEF-37581: Fix SSL certificate verification in Habitat builds and runtime

### DIFF
--- a/habitat/aarch64-darwin/plan.sh
+++ b/habitat/aarch64-darwin/plan.sh
@@ -54,6 +54,8 @@ do_build() {
   export PATH="$(pkg_path_for core/cmake)/bin:$(pkg_path_for core/make)/bin:$(pkg_path_for core/clang)/bin:$PATH"
   export CC="$(pkg_path_for core/clang)/bin/clang"
   export CXX="$(pkg_path_for core/clang)/bin/clang++"
+  export SSL_CERT_FILE="${SSL_CERT_FILE:-$(pkg_path_for core/cacerts)/ssl/certs/cacert.pem}"
+  export SSL_CERT_DIR="${SSL_CERT_DIR:-$(pkg_path_for core/cacerts)/ssl/certs}"
 
   build_line "Setting GEM_PATH=$GEM_HOME"
   export GEM_PATH="$GEM_HOME"
@@ -109,6 +111,8 @@ export PATH="$(pkg_path_for ${ruby_pkg})/bin:/sbin:/usr/sbin:/usr/local/sbin:/us
 export DYLD_LIBRARY_PATH="$(pkg_path_for core/libarchive)/lib:\$DYLD_LIBRARY_PATH"
 export GEM_HOME="$pkg_prefix/vendor"
 export GEM_PATH="$pkg_prefix/vendor"
+export SSL_CERT_FILE="\${SSL_CERT_FILE:-$(pkg_path_for core/cacerts)/ssl/certs/cacert.pem}"
+export SSL_CERT_DIR="\${SSL_CERT_DIR:-$(pkg_path_for core/cacerts)/ssl/certs}"
 
 exec $(pkg_path_for ${ruby_pkg})/bin/ruby $pkg_prefix/libexec/berks "\$@"
 EOF

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -10,6 +10,7 @@ $pkg_maintainer="The Chef Maintainers <humans@chef.io>"
 
 $pkg_deps=@(
   "core/ruby3_4-plus-devkit"
+  "core/cacerts"
 )
 $pkg_build_deps=@(
   "core/git"
@@ -40,6 +41,9 @@ function Invoke-Build {
         $env:Path += ";c:\\Program Files\\Git\\bin"
         Push-Location $project_root
         $env:GEM_HOME = "$HAB_CACHE_SRC_PATH/$pkg_dirname/vendor"
+        $cacertsPkgPath = & hab pkg path core/cacerts
+        if (-not $env:SSL_CERT_FILE) { $env:SSL_CERT_FILE = "$cacertsPkgPath/ssl/certs/cacert.pem" }
+        if (-not $env:SSL_CERT_DIR)  { $env:SSL_CERT_DIR  = "$cacertsPkgPath/ssl/certs" }
         # enable ridk for native gem build 
 
         $rubyPkgPath = & hab pkg path core/ruby3_4-plus-devkit

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -6,7 +6,7 @@ ruby_pkg="core/ruby3_4"
 pkg_maintainer="The Chef Maintainers <humans@chef.io>"
 pkg_description="Manage Chef Infra cookbooks and cookbook dependencies."
 pkg_license=('Apache-2.0')
-pkg_deps=(${ruby_pkg} core/coreutils)
+pkg_deps=(${ruby_pkg} core/coreutils core/cacerts)
 pkg_bin_dirs=(bin)
 pkg_build_deps=(
   core/make
@@ -42,6 +42,8 @@ do_unpack() {
 
 do_build() {
   export GEM_HOME="$pkg_prefix/vendor"
+  export SSL_CERT_FILE="${SSL_CERT_FILE:-$(pkg_path_for core/cacerts)/ssl/certs/cacert.pem}"
+  export SSL_CERT_DIR="${SSL_CERT_DIR:-$(pkg_path_for core/cacerts)/ssl/certs}"
 
   build_line "Setting GEM_PATH=$GEM_HOME"
   export GEM_PATH="$GEM_HOME"


### PR DESCRIPTION
<h2>CHEF-37581: Fix SSL Certificate Verification in Habitat Builds and Runtime</h2>

<h3>Problem</h3>
<p>Berkshelf was failing with an OpenSSL certificate verification error when connecting to
<code>supermarket.chef.io</code> inside Habitat-packaged environments on all platforms:</p>
<pre>
ERROR: SSL Validation failure connecting to host: supermarket.chef.io -
SSL_connect returned=1 errno=0 peeraddr=13.216.54.233:443 state=error:
certificate verify failed (unable to get local issuer certificate)

Error: Failed to generate Policyfile.lock
Reason: (OpenSSL::SSL::SSLError) SSL Error connecting to
https://supermarket.chef.io/universe - SSL_connect returned=1 errno=0
peeraddr=13.216.54.233:443 state=error: certificate verify failed
(unable to get local issuer certificate)
</pre>
<p>Root cause: OpenSSL inside the Hab-isolated environment could not locate CA
certificates because <code>SSL_CERT_FILE</code> and <code>SSL_CERT_DIR</code> were not explicitly
pointed at the <code>core/cacerts</code> package. This affected all three platforms
(Linux, macOS aarch64, Windows) during both the <code>bundle install</code> build phase
and the <code>berks</code> runtime CLI invocation.</p>

<h3>Solution</h3>
<ul>
  <li>
    <strong>Drop <code>set_runtime_env</code> / <code>Set-RuntimeEnv</code> SSL lines</strong> from
    <code>do_setup_environment</code> / <code>Invoke-SetupEnvironment</code> — the <code>core/cacerts</code>
    dependency already propagates <code>SSL_CERT_FILE</code> and <code>SSL_CERT_DIR</code> automatically
    as runtime environment variables; adding them again caused a conflict error:
    <pre>ERROR: Already have a value for $SSL_CERT_FILE, set by core/cacerts/…</pre>
  </li>
  <li>
    <strong>Use conditional assignment</strong> (<code>${VAR:-default}</code> in bash,
    <code>if (-not $env:VAR)</code> in PowerShell) in <code>do_build</code> / <code>Invoke-Build</code>
    and in the macOS aarch64 wrapper script, so a pre-set caller value is always respected
    and the fallback bakes in the correct <code>core/cacerts</code> path.
  </li>
  <li>
    <strong>Add <code>core/cacerts</code> to <code>pkg_deps</code></strong> in the Linux
    (<code>habitat/plan.sh</code>) and Windows (<code>habitat/plan.ps1</code>) plans where it was
    missing. The macOS aarch64 plan already had it.
  </li>
</ul>

<h3>Files Modified</h3>
<table>
  <thead><tr><th>File</th><th>Change</th></tr></thead>
  <tbody>
    <tr>
      <td><code>habitat/aarch64-darwin/plan.sh</code></td>
      <td>Remove SSL <code>set_runtime_env</code> lines; conditional assignment in
      <code>do_build</code> and wrapper heredoc</td>
    </tr>
    <tr>
      <td><code>habitat/plan.sh</code></td>
      <td>Add <code>core/cacerts</code> to <code>pkg_deps</code>; remove SSL
      <code>set_runtime_env</code> lines; conditional assignment in <code>do_build</code></td>
    </tr>
    <tr>
      <td><code>habitat/plan.ps1</code></td>
      <td>Add <code>core/cacerts</code> to <code>$pkg_deps</code>; remove SSL
      <code>Set-RuntimeEnv</code> lines; <code>if (-not $env:SSL_CERT_FILE)</code> guard in
      <code>Invoke-Build</code></td>
    </tr>
  </tbody>
</table>

<h3>Testing</h3>
<ul>
  <li>Verified <code>hab pkg build habitat/aarch64-darwin</code> completes without SSL errors during <code>bundle install</code></li>
  <li>Verified <code>berks install</code> resolves cookbook dependencies from <code>supermarket.chef.io</code> successfully at runtime</li>
  <li>Confirmed no <em>"Already have a value for $SSL_CERT_FILE"</em> conflict errors</li>
  <li>Confirmed pre-existing <code>SSL_CERT_FILE</code> set by a caller is preserved (conditional assignment honoured)</li>
</ul>

<h3>Checklist</h3>
<ul>
  <li>&#x2705; DCO sign-off included on commit</li>
  <li>&#x2705; All three platform plans updated (Linux, macOS aarch64, Windows)</li>
  <li>&#x2705; No breaking changes to public API or CLI behaviour</li>
  <li>&#x2705; No new gem dependencies introduced</li>
</ul>
